### PR TITLE
corrected installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Project: https://github.com/progrium/dokku
 ```
 cd /var/lib/dokku/plugins
 git clone https://github.com/ohardy/dokku-redis redis
-dokku plugins-install
+dokku plugin:install
 ```
 
 


### PR DESCRIPTION
Just a minor fix: the command is `$ dokku plugin:install`, not `$ dokku plugins-install`
